### PR TITLE
add check if plugin run in manager context

### DIFF
--- a/core/components/antispambycleantalk/elements/plugins/cleantalkCheck.plugin.php
+++ b/core/components/antispambycleantalk/elements/plugins/cleantalkCheck.plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-if( $modx->getOption('antispambycleantalk.plugin_enabled') && trim( $modx->getOption( 'antispambycleantalk.api_key' ) ) == '' ) {
+if ( ( $modx->getOption('antispambycleantalk.plugin_enabled') && trim( $modx->getOption( 'antispambycleantalk.api_key' ) ) == '' ) || $modx->context->key == 'mgr' ) {
 
     return;
 


### PR DESCRIPTION
prevents that the manager breaks (e.g. saving a user with a new password)